### PR TITLE
Fix pesde include paths

### DIFF
--- a/pkgs/analysis/pesde.toml
+++ b/pkgs/analysis/pesde.toml
@@ -1,11 +1,11 @@
 name = "alicesaidhi/conch_analysis"
 version = "0.2.0-rc.3"
-includes = ["src", "pesde.toml"]
+includes = ["src/**/*", "pesde.toml"]
 
 [target]
 environment = "luau"
 lib = "src/lib.luau"
-build_files = ["src/"]
+build_files = ["src"]
 
 [indices]
 default = "https://github.com/daimond113/pesde-index"

--- a/pkgs/ast/pesde.toml
+++ b/pkgs/ast/pesde.toml
@@ -4,7 +4,7 @@ version = "0.2.0-rc.3"
 [target]
 environment = "luau"
 lib = "src/lib.luau"
-build_files = ["src/"]
+build_files = ["src"]
 
 [indices]
 default = "https://github.com/daimond113/pesde-index"

--- a/pkgs/compiler/pesde.toml
+++ b/pkgs/compiler/pesde.toml
@@ -4,7 +4,7 @@ version = "0.2.0-rc.3"
 [target]
 environment = "luau"
 lib = "src/lib.luau"
-build_files = ["src/"]
+build_files = ["src"]
 
 [indices]
 default = "https://github.com/daimond113/pesde-index"

--- a/pkgs/glue/pesde.toml
+++ b/pkgs/glue/pesde.toml
@@ -1,11 +1,11 @@
 name = "alicesaidhi/conch"
 version = "0.2.0-rc.3"
-includes = ["src/", "pesde.toml"]
+includes = ["src/**/*", "pesde.toml"]
 
 [target]
 environment = "roblox"
 lib = "src/lib.luau"
-build_files = ["src/"]
+build_files = ["src"]
 
 [indices]
 default = "https://github.com/daimond113/pesde-index"

--- a/pkgs/types/pesde.toml
+++ b/pkgs/types/pesde.toml
@@ -4,7 +4,7 @@ version = "0.2.0-rc.3"
 [target]
 environment = "luau"
 lib = "src/lib.luau"
-build_files = ["src/lib.luau"]
+build_files = ["src"]
 
 [indices]
 default = "https://github.com/daimond113/pesde-index"

--- a/pkgs/ui/pesde.toml
+++ b/pkgs/ui/pesde.toml
@@ -1,11 +1,11 @@
 name = "alicesaidhi/conch_ui"
 version = "0.2.0-rc.3"
-includes = ["src/", "pesde.toml"]
+includes = ["src/**/*", "pesde.toml"]
 
 [target]
 environment = "roblox"
 lib = "src/lib.luau"
-build_files = ["src/"]
+build_files = ["src"]
 
 [indices]
 default = "https://github.com/daimond113/pesde-index"

--- a/pkgs/vm/pesde.toml
+++ b/pkgs/vm/pesde.toml
@@ -4,7 +4,7 @@ version = "0.2.0-rc.3"
 [target]
 environment = "luau"
 lib = "src/lib.luau"
-build_files = ["src/"]
+build_files = ["src"]
 
 [indices]
 default = "https://github.com/daimond113/pesde-index"


### PR DESCRIPTION
I've noticed `src/` only includes the `src` folder. Packages only keep the `lib.luau` file as `lib` besides that, causing them to malfunction. This is why I suggest migrating to `src/**/*` for luau files to include.