### PR TITLE
Prevent textbox from capturing focus before the menu opens

### DIFF
--- a/pkgs/ui/src/app.luau
+++ b/pkgs/ui/src/app.luau
@@ -49,10 +49,12 @@ return function()
 
 	local raw_text = source ""
 	local working = source(false)
-	local focused = source(true)
+	local focused = source(false)
 	local cursor_position = source(0)
 	local absolute_position = source(Vector2.zero)
 	local pending = source()
+
+	effect(function() focused(state.opened()) end)
 
 	local input = derive(function()
 		if pending() then

--- a/pkgs/ui/src/app.luau
+++ b/pkgs/ui/src/app.luau
@@ -49,12 +49,9 @@ return function()
 
 	local raw_text = source ""
 	local working = source(false)
-	local focused = source(false)
 	local cursor_position = source(0)
 	local absolute_position = source(Vector2.zero)
 	local pending = source()
-
-	effect(function() focused(state.opened()) end)
 
 	local input = derive(function()
 		if pending() then
@@ -142,7 +139,7 @@ return function()
 
 						enter = function(value)
 							raw_text ""
-							focused(true)
+							state.focused(true)
 
 							if pending() then
 								pending(pending().append(value))
@@ -159,8 +156,8 @@ return function()
 							end
 						end,
 
-						focused = focused,
-						update_focused = focused,
+						focused = state.focused,
+						update_focused = state.focused,
 
 						{
 							CursorPosition = cursor_position,

--- a/pkgs/ui/src/lib.luau
+++ b/pkgs/ui/src/lib.luau
@@ -2,11 +2,12 @@ local ContextActionService = game:GetService "ContextActionService"
 local Players = game:GetService "Players"
 
 local app = require "./app"
-local opened = require("./state").opened
 local conch = require "../roblox_packages/conch_glue"
+local state = require "./state"
 local vide = require "../roblox_packages/vide"
 
 local mounted = false
+local opened, focused = state.opened, state.focused
 
 local function mount()
 	if mounted then return end
@@ -17,7 +18,10 @@ end
 local function bind_to(input: Enum.KeyCode | Enum.UserInputType)
 	mount()
 	ContextActionService:BindAction("Trigger Conch", function(_, state)
-		if state == Enum.UserInputState.Begin then opened(not opened()) end
+		if state == Enum.UserInputState.Begin then
+			opened(not opened())
+			focused(opened())
+		end
 	end, false, input)
 end
 

--- a/pkgs/ui/src/state.luau
+++ b/pkgs/ui/src/state.luau
@@ -5,6 +5,7 @@ local source = vide.source
 
 return {
 	opened = source(false),
+	focused = source(false),
 
 	logs = source({} :: { conch.Log }),
 }


### PR DESCRIPTION
The text input capturing focus before conch is even open causes other inputs to sink (ex. unable to move your character) until you lose the focus by clicking. This small change makes it so it'll only capture focus when opening the menu.