### PR TITLE
Regain focus only if the UI is still open

### DIFF
--- a/pkgs/conch_ui/src/components/ui/executor.luau
+++ b/pkgs/conch_ui/src/components/ui/executor.luau
@@ -322,7 +322,13 @@ return component(function(p: {
 					runtime_plugin_api.add(value)
 
 					p.execute(value)
-					state.focused(true)
+
+					-- We only regain focus if the UI is still open because the last command
+					-- may have closed it.
+					if state.opened() then
+						state.focused(true)
+					end
+
 					raw_text ""
 					task.delay(0, raw_text, "")
 				end,


### PR DESCRIPTION
This PR fixes an issue whereby executing `close-ui` closes the UI without losing focus of it. In practice, this means the command bar and history disappears, but user input is still sunk and auto-complete appears. Users can even execute commands.

The cause of this issue is a timing interaction with FocusLost on the TextBox. When the user presses Enter to execute `close-ui`, both the `opened` and `focused` sources are set false, but `focused` is immediately set true again so that the user stays focused on the CLI. This is generally desired behavior for commands that do not close the UI (e.g. all other commands), but it is a bug when paired with `close-ui`.

The issue is fixed in this PR by checking if the UI is still open before regaining focus. There may be better ways of resolving this, but this was the simplest fix I found.